### PR TITLE
🧪 Add error handling tests for auth middleware

### DIFF
--- a/server/tests/auth_middleware.test.js
+++ b/server/tests/auth_middleware.test.js
@@ -1,0 +1,68 @@
+const jwt = require('jsonwebtoken');
+const auth = require('../middleware/auth');
+
+jest.mock('jsonwebtoken');
+
+describe('Auth Middleware Error Handling', () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = {
+      header: jest.fn().mockReturnValue('Bearer dummy_token')
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    next = jest.fn();
+
+    jest.clearAllMocks();
+  });
+
+  it('should return 401 with "Token expired" when jwt.verify throws TokenExpiredError', async () => {
+    const error = new Error('jwt expired');
+    error.name = 'TokenExpiredError';
+    jwt.verify.mockImplementation(() => {
+      throw error;
+    });
+
+    await auth(req, res, next);
+
+    expect(jwt.verify).toHaveBeenCalledWith('dummy_token', process.env.JWT_SECRET);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ success: false, errors: ['Token expired'] });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 401 with "Invalid token" when jwt.verify throws JsonWebTokenError', async () => {
+    const error = new Error('invalid token');
+    error.name = 'JsonWebTokenError';
+    jwt.verify.mockImplementation(() => {
+      throw error;
+    });
+
+    await auth(req, res, next);
+
+    expect(jwt.verify).toHaveBeenCalledWith('dummy_token', process.env.JWT_SECRET);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ success: false, errors: ['Invalid token'] });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 401 with "Authentication failed" for other errors', async () => {
+    const error = new Error('Something went wrong');
+    error.name = 'SomeOtherError';
+    jwt.verify.mockImplementation(() => {
+      throw error;
+    });
+
+    await auth(req, res, next);
+
+    expect(jwt.verify).toHaveBeenCalledWith('dummy_token', process.env.JWT_SECRET);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ success: false, errors: ['Authentication failed'] });
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `catch` block in `server/middleware/auth.js` to ensure proper error handling when verifying JWT tokens.
📊 **Coverage:** Covered edge cases where `jwt.verify` throws `TokenExpiredError`, `JsonWebTokenError`, and generic errors, ensuring the middleware responds with a 401 status and correct error messages in all three scenarios.
✨ **Result:** Increased test coverage for the authentication middleware, providing a safety net to ensure confident refactoring and that real bugs are caught.

---
*PR created automatically by Jules for task [4395842855843104488](https://jules.google.com/task/4395842855843104488) started by @NotYash1066*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for authentication middleware error handling, covering token expiration, invalid tokens, and general authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->