### PR TITLE
Improve auth refresh, logout, and password recovery flows

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,11 +7,13 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import GlobalVideoCall from "./components/video/GlobalVideoCall";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
+import ForgotPassword from "./pages/ForgotPassword";
+import ResetPassword from "./pages/ResetPassword";
 import Dashboard from "./pages/Dashboard";
 import Matches from "./pages/Matches";
 import Chat from "./pages/Chat";
 import ProfileSettings from "./pages/ProfileSettings";
-import { AUTH_STATE_CHANGE_EVENT } from "./utils/auth";
+import { AUTH_STATE_CHANGE_EVENT, clearAuthState, notifyAuthStateChange, storeAuthTokens } from "./utils/auth";
 import "./styles/App.css";
 import "./styles/themes.css";
 
@@ -25,13 +27,35 @@ function App() {
         headers: { Authorization: `Bearer ${token}` },
         timeout: 5000,
       });
-      return response.data.success;
+      return { valid: response.data.success, definitiveFailure: !response.data.success };
     } catch (error) {
       if (error.response && error.response.status === 401) {
-        return false;
+        return { valid: false, definitiveFailure: true };
       }
       console.error("Token verification failed:", error.message);
-      return false;
+      return { valid: false, definitiveFailure: false };
+    }
+  }, []);
+
+  const refreshAccessToken = useCallback(async (refreshToken) => {
+    try {
+      const response = await axios.post(
+        "/api/auth/refresh-token",
+        { refreshToken },
+        { timeout: 5000 }
+      );
+
+      return { token: response.data.token, definitiveFailure: true };
+    } catch (error) {
+      if (error.response?.status === 401) {
+        return { token: null, definitiveFailure: true };
+      }
+
+      if (error.response?.status !== 401) {
+        console.error("Token refresh failed:", error.message);
+      }
+
+      return { token: null, definitiveFailure: false };
     }
   }, []);
 
@@ -40,22 +64,53 @@ function App() {
       setLoading(true);
     }
 
-    const token = localStorage.getItem("token");
-    if (!token) {
-      setIsAuthenticated(false);
-      setLoading(false);
-      return;
-    }
+		const token = localStorage.getItem("token");
+		const refreshToken = localStorage.getItem("refreshToken");
+		if (!token) {
+		  setIsAuthenticated(false);
+		  setLoading(false);
+		  return;
+		}
 
-    const isValid = await verifyToken(token);
-    setIsAuthenticated(isValid);
+		const verificationResult = await verifyToken(token);
+		let isValid = verificationResult.valid;
 
-    if (!isValid) {
-      localStorage.removeItem("token");
-    }
+		if (!isValid && !verificationResult.definitiveFailure) {
+		  setIsAuthenticated(true);
+		  setLoading(false);
+		  return;
+		}
 
-    setLoading(false);
-  }, [verifyToken]);
+		if (!isValid && refreshToken) {
+		  const refreshResult = await refreshAccessToken(refreshToken);
+
+		  if (refreshResult.token) {
+			const newToken = refreshResult.token;
+			storeAuthTokens({ token: newToken, refreshToken });
+			const refreshedVerificationResult = await verifyToken(newToken);
+			isValid = refreshedVerificationResult.valid;
+
+			if (!isValid && !refreshedVerificationResult.definitiveFailure) {
+			  setIsAuthenticated(true);
+			  setLoading(false);
+			  return;
+			}
+		  } else if (!refreshResult.definitiveFailure) {
+			setIsAuthenticated(true);
+			setLoading(false);
+			return;
+		  }
+		}
+
+		setIsAuthenticated(isValid);
+
+		if (!isValid) {
+		  clearAuthState();
+		  notifyAuthStateChange();
+		}
+
+		setLoading(false);
+	  }, [refreshAccessToken, verifyToken]);
 
   useEffect(() => {
     const initialSyncId = window.setTimeout(() => {
@@ -67,9 +122,11 @@ function App() {
     };
 
     const handleStorage = (event) => {
-      if (!event.key || event.key === "token") {
-        void syncAuthState();
+      if (event.key && event.key !== "token" && event.key !== "refreshToken") {
+        return;
       }
+
+      void syncAuthState();
     };
 
     window.addEventListener(AUTH_STATE_CHANGE_EVENT, handleAuthStateChange);
@@ -95,7 +152,6 @@ function App() {
             v7_relativeSplatPath: true 
           }}>
           <div className="App">
-            {/* Global video call overlay mounted at app level */}
             <GlobalVideoCall />
             <Routes>
               <Route 
@@ -105,6 +161,14 @@ function App() {
               <Route 
                 path="/register" 
                 element={!isAuthenticated ? <Register /> : <Navigate to="/dashboard" />} 
+              />
+              <Route
+                path="/forgot-password"
+                element={<ForgotPassword />}
+              />
+              <Route
+                path="/reset-password/:token"
+                element={<ResetPassword />}
               />
               <Route 
                 path="/dashboard" 

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -5,7 +5,6 @@ import axios from 'axios';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { AUTH_STATE_CHANGE_EVENT } from './utils/auth';
 
-// Mock axios
 vi.mock('axios');
 
 vi.mock('./contexts/ThemeContext', () => ({
@@ -48,7 +47,6 @@ vi.mock('./pages/ProfileSettings', () => ({
   default: () => <div>Profile Settings Page</div>,
 }));
 
-// Mock socket.io-client to avoid connection errors in providers
 vi.mock('socket.io-client', () => ({
   default: () => ({
     on: vi.fn(),
@@ -59,7 +57,6 @@ vi.mock('socket.io-client', () => ({
   }),
 }));
 
-// Mock peerjs
 vi.mock('peerjs', () => ({
   Peer: vi.fn().mockImplementation(() => ({
     on: vi.fn(),
@@ -79,26 +76,20 @@ describe('App Component Auth Check', () => {
   });
 
   it('should not log an error to console when verify-token returns 401', async () => {
-    // Setup
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     localStorage.setItem('token', 'fake-token');
-    
-    // Simulate 401 error
+
     axios.get.mockRejectedValue({
       message: "Request failed with status code 401",
       response: { status: 401, data: { message: 'Unauthorized' } }
     });
 
-    // Act
     render(<App />);
 
-    // Wait for the effect to run and axios to be called
     await waitFor(() => {
         expect(axios.get).toHaveBeenCalledWith("/api/auth/verify-token", expect.any(Object));
     });
 
-    // Assert: We expect NO console.error to be called for a 401
-    // This expects the test to FAIL if the code logs the error
     expect(consoleSpy).not.toHaveBeenCalled();
   });
 
@@ -123,6 +114,35 @@ describe('App Component Auth Check', () => {
     });
 
     await waitFor(() => {
+      expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+    });
+  });
+
+  it('should refresh the access token when verification returns 401 and a refresh token exists', async () => {
+    localStorage.setItem('token', 'expired-token');
+    localStorage.setItem('refreshToken', 'valid-refresh-token');
+    window.history.pushState({}, '', '/dashboard');
+
+    axios.get
+      .mockRejectedValueOnce({
+        response: { status: 401, data: { message: 'Token expired' } },
+      })
+      .mockResolvedValueOnce({
+        data: { success: true },
+      });
+
+    axios.post.mockResolvedValueOnce({
+      data: { token: 'fresh-token' },
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith('/api/auth/refresh-token', { refreshToken: 'valid-refresh-token' }, expect.any(Object));
+    });
+
+    await waitFor(() => {
+      expect(localStorage.getItem('token')).toBe('fresh-token');
       expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
     });
   });

--- a/client/src/components/common/Navbar.jsx
+++ b/client/src/components/common/Navbar.jsx
@@ -1,19 +1,34 @@
-import React from 'react';
+import axios from 'axios';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { API_ENDPOINTS } from '../../config/api';
 import ThemeToggle from '../ThemeToggle';
 import NotificationBell from '../NotificationBell';
-import { notifyAuthStateChange } from '../../utils/auth';
+import { clearAuthState, notifyAuthStateChange } from '../../utils/auth';
 
 const Navbar = ({ user, socket }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const path = location.pathname;
 
-  const handleLogout = () => {
-    localStorage.removeItem('token');
-    localStorage.removeItem('user');
-    notifyAuthStateChange();
-    navigate('/login', { replace: true });
+  const handleLogout = async () => {
+    const token = localStorage.getItem('token');
+    const refreshToken = localStorage.getItem('refreshToken');
+
+    try {
+      if (token || refreshToken) {
+        await axios.post(
+          API_ENDPOINTS.AUTH.LOGOUT,
+          { refreshToken },
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+      }
+    } catch (error) {
+      console.error('Logout request failed:', error);
+    } finally {
+      clearAuthState();
+      notifyAuthStateChange();
+      navigate('/login', { replace: true });
+    }
   };
 
   return (

--- a/client/src/config/api.js
+++ b/client/src/config/api.js
@@ -3,7 +3,11 @@ export const API_ENDPOINTS = {
   AUTH: {
     LOGIN: `${API_BASE_URL}/api/auth/login`,
     REGISTER: `${API_BASE_URL}/api/auth/register`,
+    FORGOT_PASSWORD: `${API_BASE_URL}/api/auth/forgot-password`,
+    RESET_PASSWORD: (token) => `${API_BASE_URL}/api/auth/reset-password/${token}`,
     ME: `${API_BASE_URL}/api/auth/me`,
+    REFRESH_TOKEN: `${API_BASE_URL}/api/auth/refresh-token`,
+    LOGOUT: `${API_BASE_URL}/api/auth/logout`,
     SKILLS: `${API_BASE_URL}/api/auth/skills`,
     PROFILE: `${API_BASE_URL}/api/auth/profile`,
     USER: (id) => `${API_BASE_URL}/api/auth/user/${id}`

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import axios from 'axios';
 import { io } from 'socket.io-client';
 import { motion } from 'framer-motion';
 import { API_BASE_URL, API_ENDPOINTS } from '../config/api';
 import Navbar from '../components/common/Navbar';
+import { clearAuthState, notifyAuthStateChange } from '../utils/auth';
 
 const Dashboard = () => {
   const [user, setUser] = useState(null);
@@ -38,11 +39,12 @@ const Dashboard = () => {
     } catch (err) {
       console.error('Error fetching user data:', err);
       if (err.response?.status === 401) {
-        localStorage.removeItem('token');
+        clearAuthState();
+        notifyAuthStateChange();
         navigate('/login');
-      } else {
-        setError('We could not load your profile right now. Please try again.');
+        return;
       }
+      setError('We could not load your profile right now. Please try again.');
     } finally {
       setLoading(false);
     }

--- a/client/src/pages/ForgotPassword.jsx
+++ b/client/src/pages/ForgotPassword.jsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+import { motion } from 'framer-motion';
+import { API_ENDPOINTS } from '../config/api';
+import ThemeToggle from '../components/ThemeToggle';
+
+const ForgotPassword = () => {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    setSuccessMessage('');
+
+    try {
+      const res = await axios.post(API_ENDPOINTS.AUTH.FORGOT_PASSWORD, { email });
+      setSuccessMessage(res.data?.msg || 'If an account exists, a reset email has been sent.');
+    } catch (err) {
+      if (err.response?.data?.errors?.length > 0) {
+        setError(err.response.data.errors[0].msg);
+      } else if (err.response?.data?.msg) {
+        setError(err.response.data.msg);
+      } else if (err.response?.data?.message) {
+        setError(err.response.data.message);
+      } else {
+        setError('We could not send a reset email right now. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-surface font-body text-on-surface min-h-screen flex flex-col">
+      <main className="flex-grow flex items-center justify-center p-6 relative overflow-hidden">
+        <div className="absolute top-6 right-6 z-50">
+          <ThemeToggle />
+        </div>
+
+        <div className="absolute top-[-10%] left-[-5%] w-[40%] h-[40%] bg-surface-container-high rounded-full blur-[120px] opacity-60"></div>
+        <div className="absolute bottom-[-10%] right-[-5%] w-[35%] h-[35%] bg-secondary-container rounded-full blur-[100px] opacity-40"></div>
+
+        <motion.div
+          className="w-full max-w-[1100px] grid md:grid-cols-2 rounded-[2.5rem] overflow-hidden shadow-[0_32px_64px_-16px_rgba(48,41,80,0.12)] bg-surface-container-lowest relative z-10"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: 'easeOut' }}
+        >
+          <div className="hidden md:flex flex-col justify-between p-12 bg-gradient-to-br from-primary to-primary-container text-on-primary">
+            <div>
+              <span className="text-2xl font-black tracking-tighter text-on-primary">SkillSwap</span>
+            </div>
+            <div className="space-y-6">
+              <h1 className="text-5xl font-extrabold tracking-tight leading-[1.1]">Reset your password.</h1>
+              <p className="text-on-primary/80 text-lg max-w-sm font-medium">Enter your email address and we will send you a secure link to create a new password.</p>
+            </div>
+            <div className="text-sm font-label font-semibold uppercase tracking-[0.2em] text-on-primary/80">
+              Secure access, back in motion.
+            </div>
+          </div>
+
+          <div className="p-8 md:p-16 flex flex-col justify-center bg-surface-container-lowest">
+            <div className="mb-10">
+              <h2 className="text-3xl font-extrabold text-on-surface tracking-tight mb-2">Forgot Password</h2>
+              <p className="text-on-surface-variant font-medium">We&apos;ll email you a reset link if your account exists.</p>
+            </div>
+
+            {error && (
+              <div className="mb-6 p-4 bg-error-container text-on-error-container rounded-xl text-sm font-medium">
+                {error}
+              </div>
+            )}
+
+            {successMessage && (
+              <div className="mb-6 p-4 bg-secondary-container text-on-surface rounded-xl text-sm font-medium">
+                {successMessage}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="space-y-2">
+                <label htmlFor="forgot-password-email" className="font-label text-xs font-bold uppercase tracking-widest text-on-surface-variant block ml-1">Email Address</label>
+                <div className="relative input-container">
+                  <input
+                    id="forgot-password-email"
+                    className="w-full px-5 py-4 bg-surface-container-highest border-none rounded-xl text-on-surface placeholder:text-outline focus:ring-0 transition-all"
+                    placeholder="name@company.com"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                  />
+                  <div className="input-focus-line absolute bottom-0 left-0 w-full h-[2px] bg-primary scale-x-0 transition-transform origin-center"></div>
+                </div>
+              </div>
+
+              <button
+                className={`w-full bg-gradient-to-br from-primary to-primary-container py-4 rounded-xl text-on-primary font-bold text-lg shadow-lg shadow-primary/20 active:scale-[0.98] transition-all duration-200 ${loading ? 'opacity-70 cursor-not-allowed' : ''}`}
+                type="submit"
+                disabled={loading}
+              >
+                {loading ? 'Sending Link...' : 'Send Reset Link'}
+              </button>
+            </form>
+
+            <div className="mt-10 text-center space-y-3">
+              <p className="text-on-surface-variant font-medium">
+                Remembered it?
+                <Link className="text-primary font-bold ml-1 hover:underline underline-offset-4" to="/login">Back to Sign In</Link>
+              </p>
+              <p className="text-on-surface-variant font-medium">
+                Need an account?
+                <Link className="text-primary font-bold ml-1 hover:underline underline-offset-4" to="/register">Create one</Link>
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      </main>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { motion } from 'framer-motion';
 import { API_ENDPOINTS } from '../config/api';
 import ThemeToggle from '../components/ThemeToggle';
-import { notifyAuthStateChange } from '../utils/auth';
+import { notifyAuthStateChange, storeAuthTokens } from '../utils/auth';
 
 const Login = () => {
   const [formData, setFormData] = useState({
@@ -32,9 +32,9 @@ const Login = () => {
         password
       });
 
-      localStorage.setItem('token', res.data.token);
-      notifyAuthStateChange();
-      navigate('/dashboard', { replace: true });
+		storeAuthTokens({ token: res.data.token, refreshToken: res.data.refreshToken });
+		notifyAuthStateChange();
+		navigate('/dashboard', { replace: true });
     } catch (err) {
       if (!err.response || err.response.status !== 400) {
         console.error('Login error:', err);
@@ -119,7 +119,7 @@ const Login = () => {
               <div className="space-y-2">
                 <div className="flex justify-between items-center px-1">
                   <label htmlFor="login-password" className="font-label text-xs font-bold uppercase tracking-widest text-on-surface-variant">Password</label>
-                  <a className="font-label text-[10px] font-bold uppercase tracking-wider text-primary hover:text-primary-dim transition-colors" href="#">Forgot Password?</a>
+                  <Link className="font-label text-[10px] font-bold uppercase tracking-wider text-primary hover:text-primary-dim transition-colors" to="/forgot-password">Forgot Password?</Link>
                 </div>
                 <div className="relative input-container">
                   <input 

--- a/client/src/pages/Matches.jsx
+++ b/client/src/pages/Matches.jsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { motion } from 'framer-motion';
 import { API_ENDPOINTS } from '../config/api';
 import Navbar from '../components/common/Navbar';
+import { clearAuthState, notifyAuthStateChange } from '../utils/auth';
 
 const ensureArray = (value) => Array.isArray(value) ? value : [];
 
@@ -42,12 +43,12 @@ const Matches = () => {
       setFeaturedMatch(potential[0] ?? null);
       setMatches(potential.slice(1));
     } catch (err) {
-      console.error('Error fetching matches:', err);
-      if (err.response?.status === 401) {
-        localStorage.removeItem('token');
-        localStorage.removeItem('user');
-        navigate('/login');
-        return;
+		console.error('Error fetching matches:', err);
+		if (err.response?.status === 401) {
+			clearAuthState();
+			notifyAuthStateChange();
+			navigate('/login');
+			return;
       }
 
       setPotentialMatches([]);

--- a/client/src/pages/ProfileSettings.jsx
+++ b/client/src/pages/ProfileSettings.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { API_ENDPOINTS } from '../config/api';
 import { Button, Card, Input } from '../components/common';
+import { clearAuthState, notifyAuthStateChange } from '../utils/auth';
 import '../styles/ProfileSettings.css';
 
 const ProfileSettings = () => {
@@ -71,12 +72,14 @@ const ProfileSettings = () => {
         city: response.data.location?.city || '',
         availability: response.data.availability || []
       });
-    } catch (err) {
-      console.error('Error fetching user:', err);
-      if (err.response?.status === 401) {
-        navigate('/login');
-      }
-    }
+	} catch (err) {
+	  console.error('Error fetching user:', err);
+	  if (err.response?.status === 401) {
+		clearAuthState();
+		notifyAuthStateChange();
+		navigate('/login');
+	  }
+	}
   }, [navigate]);
 
   useEffect(() => {
@@ -127,10 +130,16 @@ const ProfileSettings = () => {
       });
       setMessage({ type: 'success', text: 'Profile updated successfully!' });
       setTimeout(() => navigate('/dashboard'), 1500);
-    } catch (err) {
-      console.error('Error updating profile:', err);
-      setMessage({ type: 'error', text: 'Failed to update profile' });
-    } finally {
+	} catch (err) {
+	  console.error('Error updating profile:', err);
+	  if (err.response?.status === 401) {
+		clearAuthState();
+		notifyAuthStateChange();
+		navigate('/login');
+		return;
+	  }
+	  setMessage({ type: 'error', text: 'Failed to update profile' });
+	} finally {
       setSaving(false);
     }
   };

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { motion } from 'framer-motion';
 import { API_ENDPOINTS } from '../config/api';
 import ThemeToggle from '../components/ThemeToggle';
-import { notifyAuthStateChange } from '../utils/auth';
+import { notifyAuthStateChange, storeAuthTokens } from '../utils/auth';
 
 const Register = () => {
   const [formData, setFormData] = useState({
@@ -41,9 +41,9 @@ const Register = () => {
         password
       });
 
-      localStorage.setItem('token', res.data.token);
-      notifyAuthStateChange();
-      navigate('/dashboard', { replace: true });
+		storeAuthTokens({ token: res.data.token, refreshToken: res.data.refreshToken });
+		notifyAuthStateChange();
+		navigate('/dashboard', { replace: true });
     } catch (err) {
       if (err.response?.data?.errors) {
         setErrors(err.response.data.errors);

--- a/client/src/pages/ResetPassword.jsx
+++ b/client/src/pages/ResetPassword.jsx
@@ -1,0 +1,165 @@
+import React, { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
+import { motion } from 'framer-motion';
+import { API_ENDPOINTS } from '../config/api';
+import ThemeToggle from '../components/ThemeToggle';
+
+const ResetPassword = () => {
+  const navigate = useNavigate();
+  const { token } = useParams();
+  const [formData, setFormData] = useState({
+    password: '',
+    confirmPassword: ''
+  });
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setSuccessMessage('');
+
+    if (formData.password !== formData.confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const res = await axios.put(API_ENDPOINTS.AUTH.RESET_PASSWORD(token), {
+        password: formData.password
+      });
+
+      setSuccessMessage(res.data?.message || 'Password reset successful. Redirecting to sign in...');
+      setFormData({ password: '', confirmPassword: '' });
+
+      window.setTimeout(() => {
+        navigate('/login', { replace: true });
+      }, 1500);
+    } catch (err) {
+      if (err.response?.data?.errors?.length > 0) {
+        setError(err.response.data.errors[0].msg);
+      } else if (err.response?.data?.msg) {
+        setError(err.response.data.msg);
+      } else if (err.response?.data?.message) {
+        setError(err.response.data.message);
+      } else {
+        setError('We could not reset your password right now. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-surface font-body text-on-surface min-h-screen flex flex-col">
+      <main className="flex-grow flex items-center justify-center p-6 relative overflow-hidden">
+        <div className="absolute top-6 right-6 z-50">
+          <ThemeToggle />
+        </div>
+
+        <div className="absolute top-[-10%] left-[-5%] w-[40%] h-[40%] bg-surface-container-high rounded-full blur-[120px] opacity-60"></div>
+        <div className="absolute bottom-[-10%] right-[-5%] w-[35%] h-[35%] bg-secondary-container rounded-full blur-[100px] opacity-40"></div>
+
+        <motion.div
+          className="w-full max-w-[1100px] grid md:grid-cols-2 rounded-[2.5rem] overflow-hidden shadow-[0_32px_64px_-16px_rgba(48,41,80,0.12)] bg-surface-container-lowest relative z-10"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: 'easeOut' }}
+        >
+          <div className="hidden md:flex flex-col justify-between p-12 bg-gradient-to-br from-primary to-primary-container text-on-primary">
+            <div>
+              <span className="text-2xl font-black tracking-tighter text-on-primary">SkillSwap</span>
+            </div>
+            <div className="space-y-6">
+              <h1 className="text-5xl font-extrabold tracking-tight leading-[1.1]">Create a new password.</h1>
+              <p className="text-on-primary/80 text-lg max-w-sm font-medium">Choose a new password for your account to get back into your studio securely.</p>
+            </div>
+            <div className="text-sm font-label font-semibold uppercase tracking-[0.2em] text-on-primary/80">
+              Token-verified access recovery.
+            </div>
+          </div>
+
+          <div className="p-8 md:p-16 flex flex-col justify-center bg-surface-container-lowest">
+            <div className="mb-10">
+              <h2 className="text-3xl font-extrabold text-on-surface tracking-tight mb-2">Reset Password</h2>
+              <p className="text-on-surface-variant font-medium">Your new password must include uppercase, lowercase, and a number.</p>
+            </div>
+
+            {error && (
+              <div className="mb-6 p-4 bg-error-container text-on-error-container rounded-xl text-sm font-medium">
+                {error}
+              </div>
+            )}
+
+            {successMessage && (
+              <div className="mb-6 p-4 bg-secondary-container text-on-surface rounded-xl text-sm font-medium">
+                {successMessage}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="space-y-2">
+                <label htmlFor="reset-password-password" className="font-label text-xs font-bold uppercase tracking-widest text-on-surface-variant block ml-1">New Password</label>
+                <div className="relative input-container">
+                  <input
+                    id="reset-password-password"
+                    className="w-full px-5 py-4 bg-surface-container-highest border-none rounded-xl text-on-surface placeholder:text-outline focus:ring-0 transition-all"
+                    placeholder="••••••••"
+                    type="password"
+                    name="password"
+                    value={formData.password}
+                    onChange={handleChange}
+                    required
+                  />
+                  <div className="input-focus-line absolute bottom-0 left-0 w-full h-[2px] bg-primary scale-x-0 transition-transform origin-center"></div>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="reset-password-confirm-password" className="font-label text-xs font-bold uppercase tracking-widest text-on-surface-variant block ml-1">Confirm New Password</label>
+                <div className="relative input-container">
+                  <input
+                    id="reset-password-confirm-password"
+                    className="w-full px-5 py-4 bg-surface-container-highest border-none rounded-xl text-on-surface placeholder:text-outline focus:ring-0 transition-all"
+                    placeholder="••••••••"
+                    type="password"
+                    name="confirmPassword"
+                    value={formData.confirmPassword}
+                    onChange={handleChange}
+                    required
+                  />
+                  <div className="input-focus-line absolute bottom-0 left-0 w-full h-[2px] bg-primary scale-x-0 transition-transform origin-center"></div>
+                </div>
+              </div>
+
+              <button
+                className={`w-full bg-gradient-to-br from-primary to-primary-container py-4 rounded-xl text-on-primary font-bold text-lg shadow-lg shadow-primary/20 active:scale-[0.98] transition-all duration-200 ${loading ? 'opacity-70 cursor-not-allowed' : ''}`}
+                type="submit"
+                disabled={loading}
+              >
+                {loading ? 'Resetting Password...' : 'Reset Password'}
+              </button>
+            </form>
+
+            <div className="mt-10 text-center">
+              <p className="text-on-surface-variant font-medium">
+                Back to
+                <Link className="text-primary font-bold ml-1 hover:underline underline-offset-4" to="/login">Sign In</Link>
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      </main>
+    </div>
+  );
+};
+
+export default ResetPassword;

--- a/client/src/tests/authFlow.test.jsx
+++ b/client/src/tests/authFlow.test.jsx
@@ -6,10 +6,8 @@ import axios from 'axios';
 import Login from '../pages/Login';
 import Register from '../pages/Register';
 
-// Mock axios
 vi.mock('axios');
 
-// Mock config to avoid import issues or dependencies on .env
 vi.mock('../config/api', () => ({
   API_ENDPOINTS: {
     AUTH: {
@@ -31,13 +29,14 @@ describe('Authentication Flow Integration', () => {
 
   it('should successfully log in and redirect to dashboard', async () => {
     const mockToken = 'mock-jwt-token';
+    const mockRefreshToken = 'mock-refresh-token';
     const mockUserEmail = 'test@example.com';
     const mockPassword = 'password123';
 
-    // Setup axios mock for successful login
     axios.post.mockResolvedValueOnce({
       data: {
         token: mockToken,
+        refreshToken: mockRefreshToken,
         user: { id: '123', email: mockUserEmail }
       }
     });
@@ -51,24 +50,20 @@ describe('Authentication Flow Integration', () => {
       </MemoryRouter>
     );
 
-    // Fill out the login form
     fireEvent.change(screen.getByLabelText(/Email Address/i), { target: { value: mockUserEmail } });
     fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: mockPassword } });
 
-    // Submit the form
     const loginButton = screen.getByRole('button', { name: /Sign In/i });
     fireEvent.click(loginButton);
 
-    // Verify loading state
     expect(screen.getByText(/Signing In.../i)).toBeInTheDocument();
 
-    // Wait for the redirect and token storage
     await waitFor(() => {
       expect(localStorage.getItem('token')).toBe(mockToken);
+      expect(localStorage.getItem('refreshToken')).toBe(mockRefreshToken);
       expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
     });
 
-    // Verify axios was called with correct data
     expect(axios.post).toHaveBeenCalledWith('/api/auth/login', {
       email: mockUserEmail,
       password: mockPassword
@@ -78,7 +73,6 @@ describe('Authentication Flow Integration', () => {
   it('should display error messages on failed login attempt', async () => {
     const errorMessage = 'Invalid credentials';
     
-    // Setup axios mock for failed login (401 Unauthorized)
     axios.post.mockRejectedValueOnce({
       response: {
         status: 401,
@@ -95,26 +89,25 @@ describe('Authentication Flow Integration', () => {
       </MemoryRouter>
     );
 
-    // Fill out and submit the form
     fireEvent.change(screen.getByLabelText(/Email Address/i), { target: { value: 'wrong@example.com' } });
     fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'wrongpass' } });
     fireEvent.click(screen.getByRole('button', { name: /Sign In/i }));
 
-    // Wait for error message to appear
     await waitFor(() => {
       expect(screen.getByText(errorMessage)).toBeInTheDocument();
     });
 
-    // Verify token was NOT stored
     expect(localStorage.getItem('token')).toBeNull();
   });
 
   it('should successfully register and redirect to dashboard', async () => {
     const mockToken = 'new-user-jwt-token';
+    const mockRefreshToken = 'new-user-refresh-token';
 
     axios.post.mockResolvedValueOnce({
       data: {
         token: mockToken,
+        refreshToken: mockRefreshToken,
         user: { id: '456', email: 'new@example.com' }
       }
     });
@@ -139,6 +132,7 @@ describe('Authentication Flow Integration', () => {
 
     await waitFor(() => {
       expect(localStorage.getItem('token')).toBe(mockToken);
+      expect(localStorage.getItem('refreshToken')).toBe(mockRefreshToken);
       expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
     });
 

--- a/client/src/tests/passwordRecovery.test.jsx
+++ b/client/src/tests/passwordRecovery.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import axios from 'axios';
+import ForgotPassword from '../pages/ForgotPassword';
+import ResetPassword from '../pages/ResetPassword';
+
+vi.mock('axios');
+
+vi.mock('../config/api', () => ({
+  API_ENDPOINTS: {
+    AUTH: {
+      FORGOT_PASSWORD: '/api/auth/forgot-password',
+      RESET_PASSWORD: (token) => `/api/auth/reset-password/${token}`,
+    },
+  },
+}));
+
+describe('Password recovery flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('submits forgot-password requests and shows the success message', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: { msg: 'If an account exists, a reset email has been sent.' },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/forgot-password']}>
+        <Routes>
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText(/Email Address/i), {
+      target: { value: 'reset@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Send Reset Link/i }));
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith('/api/auth/forgot-password', { email: 'reset@example.com' });
+      expect(screen.getByText(/If an account exists, a reset email has been sent/i)).toBeInTheDocument();
+    });
+  });
+
+  it('submits reset-password requests using the route token and shows success feedback', async () => {
+    axios.put.mockResolvedValueOnce({
+      data: { message: 'Password reset successful' },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/reset-password/test-token']}>
+        <Routes>
+          <Route path="/reset-password/:token" element={<ResetPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const passwordInputs = screen.getAllByPlaceholderText('••••••••');
+    fireEvent.change(passwordInputs[0], { target: { value: 'NewPassword1' } });
+    fireEvent.change(passwordInputs[1], { target: { value: 'NewPassword1' } });
+    fireEvent.click(screen.getByRole('button', { name: /Reset Password/i }));
+
+    await waitFor(() => {
+      expect(axios.put).toHaveBeenCalledWith('/api/auth/reset-password/test-token', {
+        password: 'NewPassword1',
+      });
+      expect(screen.getByText(/Password reset successful/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/utils/auth.js
+++ b/client/src/utils/auth.js
@@ -1,5 +1,21 @@
 export const AUTH_STATE_CHANGE_EVENT = 'skillswap-auth-state-change';
 
+export const storeAuthTokens = ({ token, refreshToken }) => {
+  if (token) {
+    localStorage.setItem('token', token);
+  }
+
+  if (refreshToken) {
+    localStorage.setItem('refreshToken', refreshToken);
+  }
+};
+
+export const clearAuthState = () => {
+  localStorage.removeItem('token');
+  localStorage.removeItem('refreshToken');
+  localStorage.removeItem('user');
+};
+
 export const notifyAuthStateChange = () => {
   if (typeof window !== 'undefined') {
     window.dispatchEvent(new Event(AUTH_STATE_CHANGE_EVENT));

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const jwt = require("jsonwebtoken");
+const crypto = require("crypto");
 const { check, validationResult } = require("express-validator");
 const bcrypt = require("bcryptjs");
 const User = require("../models/User");
@@ -92,6 +93,8 @@ router.post(
 				process.env.REFRESH_TOKEN_SECRET || process.env.JWT_SECRET,
 				{ expiresIn: "7d" }
 			);
+			user.refreshToken = refreshToken;
+			await user.save();
 			return res.json({ success: true, token, refreshToken });
 		} catch (err) {
 			return next(err);
@@ -152,6 +155,8 @@ router.post(
 				process.env.REFRESH_TOKEN_SECRET || process.env.JWT_SECRET,
 				{ expiresIn: "7d" }
 			);
+			user.refreshToken = refreshToken;
+			await user.save();
 			return res.json({ success: true, token, refreshToken });
 		} catch (err) {
 			return next(err);
@@ -343,12 +348,13 @@ router.post("/forgot-password", authLimiter, async (req, res, next) => {
 			});
 		}
 
-		// Generate secure reset token
-		const resetToken = jwt.sign(
-			{ userId: user._id, type: "password_reset" },
-			process.env.JWT_SECRET,
-			{ expiresIn: "1h" }
-		);
+		const resetToken = crypto.randomBytes(20).toString("hex");
+		user.resetPasswordToken = crypto
+			.createHash("sha256")
+			.update(resetToken)
+			.digest("hex");
+		user.resetPasswordExpire = Date.now() + 10 * 60 * 1000;
+		await user.save();
 
 		// Send email
 		const transporter = getTransporter();
@@ -361,11 +367,11 @@ router.post("/forgot-password", authLimiter, async (req, res, next) => {
           <h2>Password Reset Request</h2>
           <p>You requested a password reset for your SkillSwap account.</p>
           <p>Click the link below to reset your password:</p>
-          <a href="${process.env.CLIENT_URL}/reset-password?token=${resetToken}" 
+			  <a href="${process.env.CLIENT_URL}/reset-password/${resetToken}" 
              style="background-color: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">
             Reset Password
           </a>
-          <p>This link will expire in 1 hour.</p>
+          <p>This link will expire in 10 minutes.</p>
           <p>If you didn't request this, please ignore this email.</p>
         </div>
       `,
@@ -407,6 +413,10 @@ router.post("/refresh-token", authLimiter, async (req, res, next) => {
 			return res.status(401).json({ msg: "User not found" });
 		}
 
+		if (user.refreshToken !== refreshToken) {
+			return res.status(401).json({ msg: "Invalid refresh token" });
+		}
+
 		// Generate new access token
 		const payload = {
 			user: {
@@ -421,6 +431,56 @@ router.post("/refresh-token", authLimiter, async (req, res, next) => {
 	}
 });
 
+router.post("/logout", async (req, res, next) => {
+	try {
+		const { refreshToken } = req.body || {};
+		let userId = null;
+
+		const authHeader = req.header("Authorization") || req.header("x-auth-token");
+		const accessToken = authHeader?.startsWith("Bearer ")
+			? authHeader.replace("Bearer ", "")
+			: authHeader;
+
+		if (accessToken) {
+			try {
+				const decodedAccessToken = jwt.verify(accessToken, process.env.JWT_SECRET);
+				userId = decodedAccessToken.user?.id || null;
+			} catch (error) {
+				userId = null;
+			}
+		}
+
+		if (!userId && refreshToken) {
+			try {
+				const decodedRefreshToken = jwt.verify(
+					refreshToken,
+					process.env.REFRESH_TOKEN_SECRET || process.env.JWT_SECRET
+				);
+				userId = decodedRefreshToken.user?.id || null;
+			} catch (error) {
+				userId = null;
+			}
+		}
+
+		if (!userId) {
+			return res.status(401).json({ success: false, msg: "Invalid logout credentials" });
+		}
+
+		const user = await User.findById(userId);
+		if (!user) {
+			return res.status(401).json({ success: false, msg: "User not found" });
+		}
+
+		if (refreshToken && user.refreshToken && user.refreshToken !== refreshToken) {
+			return res.status(401).json({ success: false, msg: "Invalid refresh token" });
+		}
+
+		user.refreshToken = null;
+		await user.save();
+		res.json({ success: true, message: "Logged out successfully" });
+	} catch (err) {
+		return next(err);
+	}
+});
+
 module.exports = router;
-
-

--- a/server/routes/authExtensions.js
+++ b/server/routes/authExtensions.js
@@ -1,57 +1,10 @@
 const express = require("express");
 const router = express.Router();
-const jwt = require("jsonwebtoken");
 const { check, validationResult } = require("express-validator");
 const bcrypt = require("bcryptjs");
 const User = require("../models/User");
-const auth = require("../middleware/auth");
 const { authLimiter } = require("../middleware/rateLimit");
-const sendEmail = require('../utils/sendEmail');
-const { generateAccessToken } = require('../utils/generateTokens');
 const crypto = require('crypto');
-
-// @route   POST /api/auth/forgot-password
-// @desc    Request password reset
-router.post("/forgot-password", authLimiter, [
-	check("email").trim().isEmail().withMessage("Please include a valid email").normalizeEmail()
-], async (req, res, next) => {
-	const errors = validationResult(req);
-	if (!errors.isEmpty()) {
-		return res.status(400).json({ errors: errors.array() });
-	}
-
-	try {
-		const user = await User.findOne({ email: req.body.email });
-		if (!user) {
-			return res.status(404).json({ errors: [{ msg: "User not found" }] });
-		}
-
-		const resetToken = crypto.randomBytes(20).toString('hex');
-		user.resetPasswordToken = crypto.createHash('sha256').update(resetToken).digest('hex');
-		user.resetPasswordExpire = Date.now() + 10 * 60 * 1000; // 10 minutes
-		await user.save();
-
-		const resetUrl = `${process.env.CLIENT_URL || 'http://localhost:5173'}/reset-password/${resetToken}`;
-		const message = `You requested a password reset. Please click the following link to reset your password:\n\n${resetUrl}\n\nThis link will expire in 10 minutes.\n\nIf you did not request this, please ignore this email.`;
-
-		try {
-			await sendEmail({
-				email: user.email,
-				subject: 'Password Reset Request - SkillSwap',
-				message,
-				html: `<p>You requested a password reset.</p><p>Please click <a href="${resetUrl}">here</a> to reset your password.</p><p>This link will expire in 10 minutes.</p><p>If you did not request this, please ignore this email.</p>`
-			});
-			res.json({ success: true, message: 'Password reset email sent' });
-		} catch (err) {
-			user.resetPasswordToken = undefined;
-			user.resetPasswordExpire = undefined;
-			await user.save();
-			return res.status(500).json({ errors: [{ msg: 'Email could not be sent' }] });
-		}
-	} catch (err) {
-		return next(err);
-	}
-});
 
 // @route   PUT /api/auth/reset-password/:resettoken
 // @desc    Reset password
@@ -82,43 +35,10 @@ router.put("/reset-password/:resettoken", authLimiter, [
 		user.password = await bcrypt.hash(req.body.password, salt);
 		user.resetPasswordToken = undefined;
 		user.resetPasswordExpire = undefined;
+		user.refreshToken = null;
 		await user.save();
 
 		res.json({ success: true, message: 'Password reset successful' });
-	} catch (err) {
-		return next(err);
-	}
-});
-
-// @route   POST /api/auth/refresh-token
-// @desc    Refresh access token
-router.post("/refresh-token", async (req, res, next) => {
-	const { refreshToken } = req.body;
-	if (!refreshToken) {
-		return res.status(401).json({ errors: [{ msg: 'Refresh token required' }] });
-	}
-
-	try {
-		const decoded = jwt.verify(refreshToken, process.env.REFRESH_TOKEN_SECRET || process.env.JWT_SECRET);
-		const user = await User.findOne({ _id: decoded.id, refreshToken });
-		
-		if (!user) {
-			return res.status(403).json({ errors: [{ msg: 'Invalid refresh token' }] });
-		}
-
-		const newAccessToken = generateAccessToken(user._id);
-		res.json({ success: true, token: newAccessToken });
-	} catch (err) {
-		return res.status(403).json({ errors: [{ msg: 'Invalid refresh token' }] });
-	}
-});
-
-// @route   POST /api/auth/logout
-// @desc    Logout user (clear refresh token)
-router.post("/logout", auth, async (req, res, next) => {
-	try {
-		await User.findByIdAndUpdate(req.user.id, { refreshToken: null });
-		res.json({ success: true, message: 'Logged out successfully' });
 	} catch (err) {
 		return next(err);
 	}

--- a/server/tests/authExtensions.test.js
+++ b/server/tests/authExtensions.test.js
@@ -1,9 +1,9 @@
 const request = require('supertest');
 const mongoose = require('mongoose');
+const crypto = require('crypto');
 const app = require('../testApp');
 const User = require('../models/User');
 
-// Mock nodemailer
 jest.mock('nodemailer', () => ({
   createTransport: jest.fn().mockReturnValue({
     sendMail: jest.fn().mockResolvedValue(true)
@@ -65,6 +65,33 @@ describe('Auth Extensions', () => {
         .send({});
 
       expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe('PUT /api/auth/reset-password/:resettoken', () => {
+    it('should reset password and revoke the stored refresh token', async () => {
+      const rawResetToken = 'valid-reset-token';
+      const resetPasswordToken = crypto.createHash('sha256').update(rawResetToken).digest('hex');
+
+      const user = await User.create({
+        username: 'resetuser',
+        email: 'reset@example.com',
+        password: 'hashedpassword',
+        resetPasswordToken,
+        resetPasswordExpire: new Date(Date.now() + 5 * 60 * 1000),
+        refreshToken: 'persisted-refresh-token'
+      });
+
+      const res = await request(app)
+        .put(`/api/auth/reset-password/${rawResetToken}`)
+        .send({ password: 'NewPassword1' });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      const updatedUser = await User.findById(user._id);
+      expect(updatedUser.refreshToken).toBeNull();
+      expect(updatedUser.resetPasswordToken).toBeUndefined();
     });
   });
 });

--- a/server/tests/auth_refresh.test.js
+++ b/server/tests/auth_refresh.test.js
@@ -47,7 +47,11 @@ describe('Auth Refresh Logic', () => {
             
         expect(res.status).toBe(200);
         expect(res.body).toHaveProperty('token');
-        expect(res.body).toHaveProperty('refreshToken'); // This should FAIL now
+        expect(res.body).toHaveProperty('refreshToken');
+        expect(User.findOne).toHaveBeenCalledWith({ email: 'test@example.com' });
+        const savedUser = await User.findOne.mock.results[0].value;
+        expect(savedUser.refreshToken).toBe(res.body.refreshToken);
+        expect(savedUser.save).toHaveBeenCalled();
     });
 
     it('should allow refreshing access token with valid refresh token', async () => {
@@ -56,6 +60,12 @@ describe('Auth Refresh Logic', () => {
             'refreshsecret', // Different secret
             { expiresIn: '7d' }
         );
+
+        User.findById.mockResolvedValueOnce({
+            id: userId,
+            _id: userId,
+            refreshToken
+        });
 
         const res = await request(app)
             .post('/api/auth/refresh-token')


### PR DESCRIPTION
## Summary
- centralize client auth helpers and endpoint constants, then wire refresh-token storage and cleanup through the app shell, auth forms, navbar, and protected client views
- persist refresh tokens on the backend, add logout handling, and revoke stored refresh tokens during password resets
- add password recovery screens and extend client/server auth tests to cover refresh-token persistence and reset-time revocation

## Validation
- `cd client && npm test -- --run src/App.test.jsx src/tests/authFlow.test.jsx src/tests/passwordRecovery.test.jsx`
- `cd client && npm run build`
- `cd server && npm test -- --runInBand tests/auth_refresh.test.js`
- `cd server && npm test -- --runInBand tests/authExtensions.test.js` *(fails in `beforeAll` because the local MongoDB test instance is unavailable in this environment)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added password recovery and reset functionality for forgotten accounts
  * Implemented automatic session refresh to keep users logged in longer
  * Improved logout functionality with complete session clearing

* **Tests**
  * Added comprehensive password recovery workflow tests
  * Enhanced session handling test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->